### PR TITLE
Inner outer

### DIFF
--- a/pyspec/lib/runner.py
+++ b/pyspec/lib/runner.py
@@ -109,6 +109,5 @@ class Runner:
             self.stats.number_of_tests += len(inner.tests)
 
             for test in inner.tests:
-                if not test.success:
+                if not test.result['success']:
                     self.stats.number_of_failed_tests += 1
-

--- a/tests/test_examples/temp_spec.py
+++ b/tests/test_examples/temp_spec.py
@@ -7,7 +7,7 @@ C = pyspec.Comparisons
 
 PUB_SUB = stable.event('temp spec')
 
-TEST = pyspec.describe('this is a test', None, PUB_SUB)
+TEST = pyspec.describe('this is a test', PUB_SUB)
 
 TEST.it('can pass').expect(lambda: 1).to(C.eq, 1)
 TEST.it('can fail').expect(lambda: 1).to(C.eq, 2)


### PR DESCRIPTION
```
$ pyspec all tests

set expectations
  - can expect values: [32mok[0m
  - can expect exceptions: [32mok[0m
  - can expect a specific object type: [32mok[0m
  - can expect an object to be a member of a collection: [32mok[0m
  - can check that an iterable is empty: [32mok[0m
  - can check for the existance of specified keys in a dictionary: [32mok[0m
  - can check for the existance of specified attributes on an object: [32mok[0m
  - can check for methods on an object: [32mok[0m
use boolean operators
  - can negate an expectation using should_not: [32mok[0m
communicate failures
  - can show the expected error type: [32mok[0m
  - can show the expected error message: [32mok[0m
  - can show the expected error message when expecting an exception: [32mok[0m
let
  - can use common attributes: [32mok[0m
  - can use common methods: [32mok[0m
  - can change the value of a let in a test: [32mok[0m
  - can expect changes in a let to persist between tests: [32mok[0m
  - can defer errors thrown by a let: [32mok[0m
  - always returns the same object: [32mok[0m
  - raises the correct error when an attribute on the Test Group does not exist: [32mok[0m
before
  - is visible to the test: [32mok[0m
  - can change the value of a before in a test: [32mok[0m
  - resets the value of the before between each test: [32mok[0m
  - can defer errors thrown by a before: [32mok[0m
  - always returns the same object: [32mok[0m
  - raises the correct error when an attribute on the Test Group does not exist: [32mok[0m
outer
  inner
    - can view befores on the outer group: [32mok[0m
    - can view lets on the outer group: [32mok[0m
    - can change the value of lets defined by outer: [32mok[0m
  - but the value on outer will remain the same: [32mok[0m
generate stats info in the runner metastructure
  - has a stats object: [32mok[0m
  - tracks number the number of tests: [32mok[0m
  - tracks the success/failure rate: [32mok[0m
  - tracks time on spec_struct() using methods on Stats class: [32mok[0m
  - tracks time elapsed for running tests: [32mok[0m
create & manage metastructures
  - can create a new structure: [32mok[0m
  - initializes with no test groups: [32mok[0m
  - can add new test groups to the metastructure: [32mok[0m
  - can remove specified test groups: [32mok[0m
the cli has commands for running *_spec files
  - can run all tests in a given directory: [32mok[0m
  - can run just the tests for one file: [32mok[0m
  - can request a list of all test groups in a test directory: [32mok[0m

Tests ran: 41
Success rate: 100.0%
Total time: 2201 microseconds
```